### PR TITLE
fix fullTextAnnotation type

### DIFF
--- a/lib/src/model/annotate_image_response.dart
+++ b/lib/src/model/annotate_image_response.dart
@@ -10,7 +10,7 @@ import 'image_properties_annotation.dart';
 import 'entity_annotation.dart';
 import 'localized_object_annotation.dart';
 import 'status.dart';
-import 'text_annotation.dart';
+import 'full_text_annotation.dart';
 
 part 'annotate_image_response.g.dart';
 
@@ -46,7 +46,7 @@ class AnnotateImageResponse {
   /// completed successfully. This annotation provides the structural hierarchy
   /// for the OCR detected text.
   @JsonKey(name: 'fullTextAnnotation')
-  final TextAnnotation? fullTextAnnotation;
+  final FullTextAnnotation? fullTextAnnotation;
 
   /// If present, safe-search annotation has completed successfully.
   @JsonKey(name: 'safeSearchAnnotations')

--- a/lib/src/model/annotate_image_response.g.dart
+++ b/lib/src/model/annotate_image_response.g.dart
@@ -31,7 +31,7 @@ AnnotateImageResponse _$AnnotateImageResponseFromJson(
           .toList(),
       fullTextAnnotation: json['fullTextAnnotation'] == null
           ? null
-          : TextAnnotation.fromJson(
+          : FullTextAnnotation.fromJson(
               json['fullTextAnnotation'] as Map<String, dynamic>),
       safeSearchAnnotation: json['safeSearchAnnotations'] == null
           ? null


### PR DESCRIPTION
Replace `textAnnotation` model for `fullTextAnnotation` model in `annotate_image_response`

In `annotate_image_response` file the wrong model was used and it was not possible to obtain the data that comes in the response.