### PR TITLE
fix(api): add additional headers to concrete impl of google vision

### DIFF
--- a/packages/google_vision_flutter/lib/src/google_vision.dart
+++ b/packages/google_vision_flutter/lib/src/google_vision.dart
@@ -44,7 +44,10 @@ class GoogleVision with UiLoggy implements gv.GoogleVision {
     String apiKey, {
     Map<String, String>? additionalHeaders,
   }) {
-    _googleVision.withApiKey(apiKey);
+    _googleVision.withApiKey(
+      apiKey,
+      additionalHeaders: additionalHeaders,
+    );
 
     return this;
   }


### PR DESCRIPTION
The author forgot to add `additionalHeaders` param when override `withApiKey`