### PR TITLE
Fix color fromJson method

### DIFF
--- a/packages/google_vision/lib/src/model/color.dart
+++ b/packages/google_vision/lib/src/model/color.dart
@@ -23,12 +23,15 @@ part 'color.g.dart';
 @JsonSerializable()
 class Color {
   /// The amount of red in the color as a value in the interval \[0, 1\].
+  @JsonKey(defaultValue: 0.0)
   final double red;
 
   /// The amount of green in the color as a value in the interval \[0, 1\].
+  @JsonKey(defaultValue: 0.0)
   final double green;
 
   /// The amount of blue in the color as a value in the interval \[0, 1\].
+  @JsonKey(defaultValue: 0.0)
   final double blue;
 
   /// The amount of alpha in the color as a value in the interval \[0, 1\].

--- a/packages/google_vision/lib/src/model/color.g.dart
+++ b/packages/google_vision/lib/src/model/color.g.dart
@@ -7,9 +7,9 @@ part of 'color.dart';
 // **************************************************************************
 
 Color _$ColorFromJson(Map<String, dynamic> json) => Color(
-      red: (json['red'] as num).toDouble(),
-      green: (json['green'] as num).toDouble(),
-      blue: (json['blue'] as num).toDouble(),
+      red: (json['red'] as num?)?.toDouble() ?? 0.0,
+      green: (json['green'] as num?)?.toDouble() ?? 0.0,
+      blue: (json['blue'] as num?)?.toDouble() ?? 0.0,
       alpha: (json['alpha'] as num?)?.toDouble(),
     );
 

--- a/packages/google_vision/lib/src/provider/files.g.dart
+++ b/packages/google_vision/lib/src/provider/files.g.dart
@@ -9,11 +9,7 @@ part of 'files.dart';
 // ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
 
 class _FilesClient implements FilesClient {
-  _FilesClient(
-    this._dio, {
-    this.baseUrl,
-    this.errorLogger,
-  }) {
+  _FilesClient(this._dio, {this.baseUrl, this.errorLogger}) {
     baseUrl ??= 'https://vision.googleapis.com/v1';
   }
 
@@ -34,23 +30,21 @@ class _FilesClient implements FilesClient {
     _headers.removeWhere((k, v) => v == null);
     final _data = <String, dynamic>{};
     _data.addAll(params);
-    final _options = _setStreamType<BatchAnnotateFilesResponse>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-      contentType: contentType,
-    )
-        .compose(
-          _dio.options,
-          '/files:annotate',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        )));
+    final _options = _setStreamType<BatchAnnotateFilesResponse>(
+      Options(
+        method: 'POST',
+        headers: _headers,
+        extra: _extra,
+        contentType: contentType,
+      )
+          .compose(
+            _dio.options,
+            '/files:annotate',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
     final _result = await _dio.fetch<Map<String, dynamic>>(_options);
     late BatchAnnotateFilesResponse _value;
     try {
@@ -75,10 +69,7 @@ class _FilesClient implements FilesClient {
     return requestOptions;
   }
 
-  String _combineBaseUrls(
-    String dioBaseUrl,
-    String? baseUrl,
-  ) {
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
     if (baseUrl == null || baseUrl.trim().isEmpty) {
       return dioBaseUrl;
     }

--- a/packages/google_vision/lib/src/provider/images.g.dart
+++ b/packages/google_vision/lib/src/provider/images.g.dart
@@ -9,11 +9,7 @@ part of 'images.dart';
 // ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
 
 class _ImagesClient implements ImagesClient {
-  _ImagesClient(
-    this._dio, {
-    this.baseUrl,
-    this.errorLogger,
-  }) {
+  _ImagesClient(this._dio, {this.baseUrl, this.errorLogger}) {
     baseUrl ??= 'https://vision.googleapis.com/v1';
   }
 
@@ -34,23 +30,21 @@ class _ImagesClient implements ImagesClient {
     _headers.removeWhere((k, v) => v == null);
     final _data = <String, dynamic>{};
     _data.addAll(params);
-    final _options = _setStreamType<BatchAnnotateImagesResponse>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-      contentType: contentType,
-    )
-        .compose(
-          _dio.options,
-          '/images:annotate',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        )));
+    final _options = _setStreamType<BatchAnnotateImagesResponse>(
+      Options(
+        method: 'POST',
+        headers: _headers,
+        extra: _extra,
+        contentType: contentType,
+      )
+          .compose(
+            _dio.options,
+            '/images:annotate',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
     final _result = await _dio.fetch<Map<String, dynamic>>(_options);
     late BatchAnnotateImagesResponse _value;
     try {
@@ -75,10 +69,7 @@ class _ImagesClient implements ImagesClient {
     return requestOptions;
   }
 
-  String _combineBaseUrls(
-    String dioBaseUrl,
-    String? baseUrl,
-  ) {
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
     if (baseUrl == null || baseUrl.trim().isEmpty) {
       return dioBaseUrl;
     }

--- a/packages/google_vision/lib/src/provider/oauth.g.dart
+++ b/packages/google_vision/lib/src/provider/oauth.g.dart
@@ -9,11 +9,7 @@ part of 'oauth.dart';
 // ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
 
 class _OAuthClient implements OAuthClient {
-  _OAuthClient(
-    this._dio, {
-    this.baseUrl,
-    this.errorLogger,
-  }) {
+  _OAuthClient(this._dio, {this.baseUrl, this.errorLogger}) {
     baseUrl ??= 'https://accounts.google.com/o/oauth2';
   }
 
@@ -28,28 +24,26 @@ class _OAuthClient implements OAuthClient {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{
-      r'Content-Type': 'application/x-www-form-urlencoded'
+      r'Content-Type': 'application/x-www-form-urlencoded',
     };
     _headers.removeWhere((k, v) => v == null);
     final _data = <String, dynamic>{};
     _data.addAll(params);
-    final _options = _setStreamType<Token>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-      contentType: 'application/x-www-form-urlencoded',
-    )
-        .compose(
-          _dio.options,
-          '/token',
-          queryParameters: queryParameters,
-          data: _data,
-        )
-        .copyWith(
-            baseUrl: _combineBaseUrls(
-          _dio.options.baseUrl,
-          baseUrl,
-        )));
+    final _options = _setStreamType<Token>(
+      Options(
+        method: 'POST',
+        headers: _headers,
+        extra: _extra,
+        contentType: 'application/x-www-form-urlencoded',
+      )
+          .compose(
+            _dio.options,
+            '/token',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
     final _result = await _dio.fetch<Map<String, dynamic>>(_options);
     late Token _value;
     try {
@@ -74,10 +68,7 @@ class _OAuthClient implements OAuthClient {
     return requestOptions;
   }
 
-  String _combineBaseUrls(
-    String dioBaseUrl,
-    String? baseUrl,
-  ) {
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
     if (baseUrl == null || baseUrl.trim().isEmpty) {
       return dioBaseUrl;
     }


### PR DESCRIPTION
In my project I found out that google vision api can return color result without any of red, green or blue keys. In this case crash occurs in the project:

> I/flutter (10689): Exception: Failed to analyze image: type 'Null' is not a subtype of type 'num' in type cast
> I/flutter (10689): #0      _$ColorFromJson (package:google_vision/src/model/color.g.dart:12:27)
> I/flutter (10689): #1      new Color.fromJson (package:google_vision/src/model/color.dart:44:56)
> I/flutter (10689): #2      _$ColorInfoFromJson (package:google_vision/src/model/color_info.g.dart:10:20)
> I/flutter (10689): #3      new ColorInfo.fromJson (package:google_vision/src/model/color_info.dart:30:7)
> I/flutter (10689): #4      _$DominantColorsAnnotationFromJson.<anonymous closure> (package:google_vision/src/model/dominant_colors_annotation.g.dart:13:33)
> I/flutter (10689): #5      MappedListIterable.elementAt (dart:_internal/iterable.dart:442:31)
> I/flutter (10689): #6      ListIterator.moveNext (dart:_internal/iterable.dart:371:26)
> I/flutter (10689): #7      new _GrowableList._ofEfficientLengthIterable (dart:core-patch/growable_array.dart:190:27)
> I/flutter (10689): #8      new _GrowableList.of (dart:core-patch/growable_array.dart:150:28)
> I/flutter (10689): #9      new List.of (dart:core-patch/array_patch.dart:40:18)
> I/flutter (10689): #10     ListIterable.toList (dart:_internal/iterable.dart:224:7)
> I/flutter (10689): #11     _$DominantColorsAnnotationFromJson (package:google_vision/src/model/dominant_colors_annotation.g.dart:14:12)

Example of dominant colors answer with this issue:

> {colors: [{color: {red: 152, green: 29, blue: 35}, score: 0.8676978, pixelFraction: 0.47688422}, {color: {red: 113, green: 20, blue: 16}, score: 0.048836235, pixelFraction: 0.045778297}, **`{color: {red: 57, green: 9},`** score: 0.0035934444, pixelFraction: 0.0022015022}, {color: {red: 249, green: 250, blue: 250}, score: 0.0013255983, pixelFraction: 0.31047657}, {color: {red: 153, green: 103, blue: 106}, score: 0.00089046493, pixelFraction: 0.0047267545}, {color: {red: 102, green: 21, blue: 18}, score: 0.030535169, pixelFraction: 0.024993526}, {color: {red: 129, green: 23, blue: 23}, score: 0.0198324, pixelFraction: 0.047461797}, {color: {red: 143, green: 30, blue: 39}, score: 0.010534447, pixelFraction: 0.018324269}, {color: {red: 133, green: 47, blue: 50}, score: 0.0059493077, pixelFraction: 0.016640767}, {color: {red: 133, green: 35, blue: 28}, score: 0.0048507415, pixelFraction: 0.007834758}]}

The following changes set 0 as the default value in case no red/green/blue key is provided.